### PR TITLE
Updated llama-cpp-python with Pypi

### DIFF
--- a/runtime/pixi.lock
+++ b/runtime/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/pytorch/
     - url: https://conda.anaconda.org/xformers/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -51,23 +53,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/confection-0.1.4-py310h17c5347_0.conda
       - conda: https://conda.anaconda.org/pytorch/noarch/cpuonly-2.0-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-12.6.37-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-12.6.37-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-12.6.20-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-12.6-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cymem-2.0.8-py310hc6cd4ac_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cython-blis-0.7.10-py310h1f7b6fc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dataclasses-json-0.6.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/einops-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.112.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py310h2372a71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
@@ -114,7 +106,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-6_ha36c22a_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.6.0.22-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.1-hdb1bdb2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
@@ -149,8 +140,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.11.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llama-cpp-python-0.2.24-py310hc6cd4ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llama.cpp-0.0.1660-cuda120_h7e1319f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py310h4c7c693_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.0-py310hff52083_0.conda
@@ -196,7 +185,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.5.0-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
@@ -230,9 +218,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/spacy-loggers-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.32-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/srsly-2.4.8-py310hc6cd4ac_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-context-0.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h434a139_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.5.0-pyhd8ed1ab_0.conda
@@ -252,7 +237,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py310hff52083_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wasabi-1.1.2-py310hff52083_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/weasel-0.4.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
@@ -265,6 +249,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py310h64cae3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - pypi: https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/14/85052d76d7f92ed97de7a7bc54f6b6cc04c2c25f6d8775cfe37d976e1842/llama_cpp_python-0.3.1.tar.gz
   default:
     channels:
     - url: https://conda.anaconda.org/nvidia/
@@ -278,6 +264,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/pytorch/
     - url: https://conda.anaconda.org/xformers/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -339,14 +327,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/dataclasses-json-0.6.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/einops-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.112.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fastrlock-0.8.2-py310hc6cd4ac_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py310h2372a71_0.conda
@@ -437,8 +419,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.11.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llama-cpp-python-0.2.24-py310hc6cd4ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llama.cpp-0.0.1660-cuda118_h985c7a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py310h4c7c693_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.0-py310hff52083_0.conda
@@ -485,7 +465,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.5.0-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
@@ -520,9 +499,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/spacy-loggers-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.32-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/srsly-2.4.8-py310hc6cd4ac_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-context-0.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h434a139_3.conda
@@ -544,7 +520,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py310hff52083_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wasabi-1.1.2-py310hff52083_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/weasel-0.4.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
@@ -558,6 +533,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py310h64cae3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - pypi: https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/14/85052d76d7f92ed97de7a7bc54f6b6cc04c2c25f6d8775cfe37d976e1842/llama_cpp_python-0.3.1.tar.gz
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -599,6 +576,7 @@ packages:
   md5: 23b8f98a355030331f40d0245492f715
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 7938
   timestamp: 1538887428262
 - kind: conda
@@ -612,6 +590,7 @@ packages:
   md5: 7702188077361f43a4d61e64c694f850
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 12330
   timestamp: 1644957785078
 - kind: conda
@@ -626,6 +605,7 @@ packages:
   md5: 1c005af0c6ff22814b7c52ee448d4bea
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 20798
   timestamp: 1720621358501
 - kind: conda
@@ -1178,6 +1158,8 @@ packages:
   - scipy
   - sysroot_linux-64 >=2.17
   license: MIT
+  purls:
+  - pkg:pypi/bitsandbytes?source=conda-forge-mapping
   size: 7022276
   timestamp: 1725018972359
 - kind: conda
@@ -1434,39 +1416,6 @@ packages:
   size: 201959
   timestamp: 1663787236799
 - kind: conda
-  name: cuda-cudart
-  version: 12.6.37
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-12.6.37-0.tar.bz2
-  sha256: bda133a29f443fe905a3c5556f53697ea3e9dc4aef00859449716cb5864f5bfc
-  md5: cecd16b68efaa05287b68b6861a7fe82
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-cudart_linux-64 12.6.37 0
-  - cuda-version >=12.6,<12.7.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  purls: []
-  size: 17379
-  timestamp: 1721100949993
-- kind: conda
-  name: cuda-cudart_linux-64
-  version: 12.6.37
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-12.6.37-0.tar.bz2
-  sha256: e43be538e7aaab58e0475e45f04a4c238e17f6e044d40f4dd59d0fb466ae68c0
-  md5: 625fece7aaa687733fa1d4ade409425a
-  depends:
-  - cuda-version >=12.6,<12.7.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  purls: []
-  size: 220835
-  timestamp: 1721100938846
-- kind: conda
   name: cuda-cupti
   version: 11.8.87
   build: '0'
@@ -1511,23 +1460,6 @@ packages:
   size: 20069921
   timestamp: 1663786884512
 - kind: conda
-  name: cuda-nvrtc
-  version: 12.6.20
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-12.6.20-0.tar.bz2
-  sha256: 307d475d96b139e7aa527581f3205d11370e1999bcc6bd311a2c24fe8e4e371e
-  md5: a25d3bd7f720e3412c021d2ca1598ca7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-version >=12.6,<12.7.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  purls: []
-  size: 21193248
-  timestamp: 1720730462609
-- kind: conda
   name: cuda-nvtx
   version: 11.8.86
   build: '0'
@@ -1568,23 +1500,6 @@ packages:
   purls: []
   size: 21043
   timestamp: 1709765911943
-- kind: conda
-  name: cuda-version
-  version: '12.6'
-  build: '3'
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/nvidia/noarch/cuda-version-12.6-3.tar.bz2
-  sha256: 41ebffac7499ae538067e18a539b2f55bf10a85725488f353900093d1ce206e0
-  md5: 99c0a21508bd0642d019dd021b30eb9c
-  constrains:
-  - __cuda >=12
-  - cudatoolkit 12.6|12.6.*
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  purls: []
-  size: 16804
-  timestamp: 1722029877075
 - kind: conda
   name: cudatoolkit
   version: 11.8.0
@@ -1714,6 +1629,8 @@ packages:
   - typing_inspect >=0.4.0,<1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/dataclasses-json?source=conda-forge-mapping
   size: 30290
   timestamp: 1717969432285
 - kind: conda
@@ -1764,51 +1681,12 @@ packages:
   - pkg:pypi/dill?source=conda-forge-mapping
   size: 87553
   timestamp: 1690101185422
-- kind: conda
+- kind: pypi
   name: diskcache
   version: 5.6.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-  sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  md5: 4c33109f652b5d8c995ab243436c9370
-  depends:
-  - python >=3.5
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/diskcache?source=conda-forge-mapping
-  size: 40074
-  timestamp: 1693471512435
-- kind: conda
-  name: dnspython
-  version: 2.6.1
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
-  sha256: 0d52c878553e569bccfbd96472c1659fb873bc05e95911b457d35982827626fe
-  md5: 936e6aadb75534384d11d982fab74b61
-  depends:
-  - python >=3.8.0,<4.0.0
-  - sniffio
-  constrains:
-  - h2 >=4.1.0
-  - httpcore >=1.0.0
-  - wmi >=1.5.1
-  - trio >=0.23
-  - aioquic >=0.9.25
-  - cryptography >=42
-  - idna >=3.6
-  - httpx >=0.26.0
-  license: ISC
-  license_family: OTHER
-  purls:
-  - pkg:pypi/dnspython?source=conda-forge-mapping
-  size: 169434
-  timestamp: 1709190848615
+  url: https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl
+  sha256: 5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
+  requires_python: '>=3'
 - kind: conda
   name: einops
   version: 0.8.0
@@ -1827,40 +1705,6 @@ packages:
   size: 40293
   timestamp: 1714285282316
 - kind: conda
-  name: email-validator
-  version: 2.2.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
-  sha256: ea9e936ed7c49ea6d66fa3554afe31ba311f2a3d5e384d8c38925fda9e37bdb9
-  md5: 3067adf57ee658ddf5bfad47b0041ce4
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.7
-  license: Unlicense
-  purls:
-  - pkg:pypi/email-validator?source=conda-forge-mapping
-  size: 44157
-  timestamp: 1718984716782
-- kind: conda
-  name: email_validator
-  version: 2.2.0
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
-  sha256: 2cbbbe9e0f3872214227c27b8b775dd2296a435c90ef50a7cc69934c329b6c65
-  md5: 0214a004f7cf5ac28fc10a390dfc47ee
-  depends:
-  - email-validator >=2.2.0,<2.2.1.0a0
-  license: Unlicense
-  purls:
-  - pkg:pypi/email-validator?source=conda-forge-mapping
-  size: 6690
-  timestamp: 1718984720419
-- kind: conda
   name: exceptiongroup
   version: 1.2.2
   build: pyhd8ed1ab_0
@@ -1876,52 +1720,6 @@ packages:
   - pkg:pypi/exceptiongroup?source=conda-forge-mapping
   size: 20418
   timestamp: 1720869435725
-- kind: conda
-  name: fastapi
-  version: 0.112.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.112.2-pyhd8ed1ab_0.conda
-  sha256: b6d0e4894d47a9247b8a24347a2e276fc0443b55b63d5237c9b68601e18564f3
-  md5: f74491e68b58995125541f032f25c56f
-  depends:
-  - email_validator >=2.0.0
-  - fastapi-cli >=0.0.5
-  - httpx >=0.23.0
-  - jinja2 >=2.11.2
-  - pydantic >=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
-  - python >=3.8
-  - python-multipart >=0.0.7
-  - starlette >=0.37.2,<0.39.0
-  - typing-extensions >=4.8.0
-  - uvicorn >=0.12.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/fastapi?source=conda-forge-mapping
-  size: 72073
-  timestamp: 1724620381873
-- kind: conda
-  name: fastapi-cli
-  version: 0.0.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
-  sha256: 72a8b8f55420207086cacf15066e234556669b4f3d6f5f8555a93a0013ed9bc9
-  md5: d50cd55f356225d8440741bb911c2a78
-  depends:
-  - fastapi
-  - python >=3.8
-  - typer >=0.12.3
-  - uvicorn >=0.15.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/fastapi-cli?source=conda-forge-mapping
-  size: 14405
-  timestamp: 1722597753588
 - kind: conda
   name: fastrlock
   version: 0.8.2
@@ -2414,6 +2212,7 @@ packages:
   - sysroot_linux-64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 944344
   timestamp: 1720621422017
 - kind: conda
@@ -2491,6 +2290,8 @@ packages:
   - jsonschema >=4.22.0,<5
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/langchain?source=conda-forge-mapping
   size: 430992
   timestamp: 1728449542974
 - kind: conda
@@ -2517,6 +2318,8 @@ packages:
   - tenacity >=8.1.0,<9.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/langchain-community?source=conda-forge-mapping
   size: 1158538
   timestamp: 1728470033519
 - kind: conda
@@ -2540,6 +2343,8 @@ packages:
   - jinja2 >=3.0.0,<4.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/langchain-core?source=conda-forge-mapping
   size: 264520
   timestamp: 1728444986484
 - kind: conda
@@ -2559,6 +2364,8 @@ packages:
   - beautifulsoup4 >=4.12.3,<5.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/langchain-text-splitters?source=conda-forge-mapping
   size: 26692
   timestamp: 1726389705883
 - kind: conda
@@ -2596,6 +2403,8 @@ packages:
   - requests >=2.0.0,<3.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/langsmith?source=conda-forge-mapping
   size: 255763
   timestamp: 1727415343522
 - kind: conda
@@ -2877,24 +2686,6 @@ packages:
   size: 381637889
   timestamp: 1662499145253
 - kind: conda
-  name: libcublas
-  version: 12.6.0.22
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.6.0.22-0.tar.bz2
-  sha256: 9f22a60173b66d7943d139db78a316a8eaab8b018db8e4703a7ce5055e5a9390
-  md5: 0fc5487b74b04eca6e3ef7ca3f64fdbd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-nvrtc
-  - cuda-version >=12.6,<12.7.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  purls: []
-  size: 342769180
-  timestamp: 1721102148604
-- kind: conda
   name: libcufft
   version: 10.9.0.58
   build: '0'
@@ -3053,6 +2844,7 @@ packages:
   - libgcc-ng ==14.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 846380
   timestamp: 1724801836552
 - kind: conda
@@ -3068,6 +2860,7 @@ packages:
   - libgcc 14.1.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 52170
   timestamp: 1724801842101
 - kind: conda
@@ -3434,6 +3227,7 @@ packages:
   - libgcc 14.1.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 3892781
   timestamp: 1724801863728
 - kind: conda
@@ -3449,6 +3243,7 @@ packages:
   - libstdcxx 14.1.0 hc0a3c3a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 52219
   timestamp: 1724801897766
 - kind: conda
@@ -3533,6 +3328,7 @@ packages:
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 3197061
   timestamp: 1727635479085
 - kind: conda
@@ -3556,6 +3352,7 @@ packages:
   - nccl >=2.23.4.1,<3.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 99679832
   timestamp: 1727638593965
 - kind: conda
@@ -3616,72 +3413,39 @@ packages:
   - pkg:pypi/lightning-utilities?source=conda-forge-mapping
   size: 27511
   timestamp: 1721751646737
-- kind: conda
+- kind: pypi
   name: llama-cpp-python
-  version: 0.2.24
-  build: py310hc6cd4ac_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llama-cpp-python-0.2.24-py310hc6cd4ac_0.conda
-  sha256: c4bdf849186832913b9cafc371bad1d80c88f631f7bf9c24be55104a65129163
-  md5: 40b2bf1cd2c8b1f316aa1a69d8fb6ff6
-  depends:
-  - diskcache >=5.6.1
-  - fastapi >=0.100.0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - llama.cpp 0.0.1660.*
-  - numpy >=1.20.0
-  - pydantic-settings >=2.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - sse-starlette >=1.6.1
-  - starlette-context >=0.3.6,<0.4
-  - typing-extensions >=4.5.0
-  - uvicorn >=0.22.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/llama-cpp-python?source=conda-forge-mapping
-  size: 216839
-  timestamp: 1703026723070
-- kind: conda
-  name: llama.cpp
-  version: 0.0.1660
-  build: cuda118_h985c7a6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llama.cpp-0.0.1660-cuda118_h985c7a6_0.conda
-  sha256: b27f5901d6fdb7ede8137d4f197e854d9eccb5e2943de36824fd075bc461972a
-  md5: 0c099e672444f195fdb46a7a07f294b7
-  depends:
-  - __glibc >=2.17
-  - cuda-version 11.8.*
-  - cudatoolkit >=11.8,<12
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 6415908
-  timestamp: 1703018002562
-- kind: conda
-  name: llama.cpp
-  version: 0.0.1660
-  build: cuda120_h7e1319f_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llama.cpp-0.0.1660-cuda120_h7e1319f_0.conda
-  sha256: 208be02b9f32537bd1bea5a22c495f1a35536171580c40dbabc3228574a6ba86
-  md5: 0827d72035a664498edfae88e55c1d9d
-  depends:
-  - cuda-cudart >=12.0.107,<13.0a0
-  - cuda-version >=12.0,<13
-  - libcublas >=12.0.1.189,<13.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 6268853
-  timestamp: 1703017775051
+  version: 0.3.1
+  url: https://files.pythonhosted.org/packages/b5/14/85052d76d7f92ed97de7a7bc54f6b6cc04c2c25f6d8775cfe37d976e1842/llama_cpp_python-0.3.1.tar.gz
+  sha256: 75ec8374960b6353c254e55a48e7c7783abf6bcb9178ba0f655490738e5a9004
+  requires_dist:
+  - typing-extensions>=4.5.0
+  - numpy>=1.20.0
+  - diskcache>=5.6.1
+  - jinja2>=2.11.3
+  - uvicorn>=0.22.0 ; extra == 'server'
+  - fastapi>=0.100.0 ; extra == 'server'
+  - pydantic-settings>=2.0.1 ; extra == 'server'
+  - sse-starlette>=1.6.1 ; extra == 'server'
+  - starlette-context<0.4,>=0.3.6 ; extra == 'server'
+  - pyyaml>=5.1 ; extra == 'server'
+  - pytest>=7.4.0 ; extra == 'test'
+  - httpx>=0.24.1 ; extra == 'test'
+  - scipy>=1.10 ; extra == 'test'
+  - fastapi>=0.100.0 ; extra == 'test'
+  - sse-starlette>=1.6.1 ; extra == 'test'
+  - starlette-context<0.4,>=0.3.6 ; extra == 'test'
+  - pydantic-settings>=2.0.1 ; extra == 'test'
+  - huggingface-hub>=0.23.0 ; extra == 'test'
+  - black>=23.3.0 ; extra == 'dev'
+  - twine>=4.0.2 ; extra == 'dev'
+  - mkdocs>=1.4.3 ; extra == 'dev'
+  - mkdocstrings[python]>=0.22.0 ; extra == 'dev'
+  - mkdocs-material>=9.1.18 ; extra == 'dev'
+  - pytest>=7.4.0 ; extra == 'dev'
+  - httpx>=0.24.1 ; extra == 'dev'
+  - llama-cpp-python[dev,server,test] ; extra == 'all'
+  requires_python: '>=3.8'
 - kind: conda
   name: llvm-openmp
   version: 15.0.7
@@ -3824,6 +3588,8 @@ packages:
   - packaging >=17.0
   - python >=3.8
   license: MIT AND BSD-3-Clause
+  purls:
+  - pkg:pypi/marshmallow?source=conda-forge-mapping
   size: 92188
   timestamp: 1724261086984
 - kind: conda
@@ -3985,6 +3751,8 @@ packages:
   - python >=3.5
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mypy-extensions?source=conda-forge-mapping
   size: 10492
   timestamp: 1675543414256
 - kind: conda
@@ -4004,6 +3772,7 @@ packages:
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 133517524
   timestamp: 1727484668754
 - kind: conda
@@ -4246,6 +4015,8 @@ packages:
   - transformers >=4.18.0
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/peft?source=conda-forge-mapping
   size: 145025
   timestamp: 1721857578938
 - kind: conda
@@ -4344,6 +4115,8 @@ packages:
   - scipy
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/xgboost?source=conda-forge-mapping
   size: 134436
   timestamp: 1727635360689
 - kind: conda
@@ -4367,6 +4140,8 @@ packages:
   - scipy
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/xgboost?source=conda-forge-mapping
   size: 134090
   timestamp: 1727638700750
 - kind: conda
@@ -4623,23 +4398,6 @@ packages:
   - pkg:pypi/python-dotenv?source=conda-forge-mapping
   size: 24278
   timestamp: 1706018281544
-- kind: conda
-  name: python-multipart
-  version: 0.0.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
-  sha256: 026467128031bd667c4a32555ae07e922d5caed257e4815c44e7338887bbd56a
-  md5: 0eef653965f0fed2013924d08089f371
-  depends:
-  - python >=3.7
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/python-multipart?source=conda-forge-mapping
-  size: 26439
-  timestamp: 1707760278735
 - kind: conda
   name: python-tzdata
   version: '2024.1'
@@ -5075,6 +4833,8 @@ packages:
   - transformers >=3.1
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/sentence-transformers?source=conda-forge-mapping
   size: 83596
   timestamp: 1626294595130
 - kind: conda
@@ -5377,63 +5137,6 @@ packages:
   size: 570057
   timestamp: 1695654132181
 - kind: conda
-  name: sse-starlette
-  version: 2.1.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.1.3-pyhd8ed1ab_0.conda
-  sha256: 6d671a66333410ec7e5e7858a252565a9001366726d1fe3c3a506d7156169085
-  md5: 3918255c942c242ed5599e10329e8d0e
-  depends:
-  - anyio
-  - python >=3.8
-  - starlette
-  - uvicorn
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/sse-starlette?source=conda-forge-mapping
-  size: 14712
-  timestamp: 1722520112550
-- kind: conda
-  name: starlette
-  version: 0.38.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.2-pyhd8ed1ab_0.conda
-  sha256: a9f2e202ba06514702590dd864cbcdd87b3d7a08b535e6b680798f39a6432356
-  md5: 4514ed54fc1b95a9d1f4d7cb126601a2
-  depends:
-  - anyio <5,>=3.4.0
-  - python >=3.8
-  - typing_extensions >=3.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/starlette?source=conda-forge-mapping
-  size: 57626
-  timestamp: 1722370674470
-- kind: conda
-  name: starlette-context
-  version: 0.3.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/starlette-context-0.3.6-pyhd8ed1ab_0.conda
-  sha256: 656048ca039380f6aaf6f0b7684b81b28427a580e4f177fddd7cb0d82c4cb451
-  md5: b5c1b70a046c53e8b617853aa4d94899
-  depends:
-  - python >=3.8,<4.0
-  - starlette
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/starlette-context?source=conda-forge-mapping
-  size: 14933
-  timestamp: 1676743549745
-- kind: conda
   name: sympy
   version: 1.13.2
   build: pypyh2585a3b_103
@@ -5471,6 +5174,7 @@ packages:
   - tzdata
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 15513240
   timestamp: 1720621429816
 - kind: conda
@@ -5805,6 +5509,8 @@ packages:
   - typing_extensions >=3.7.4
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspect?source=conda-forge-mapping
   size: 14906
   timestamp: 1685820229594
 - kind: conda
@@ -5843,26 +5549,6 @@ packages:
   - pkg:pypi/urllib3?source=conda-forge-mapping
   size: 95048
   timestamp: 1719391384778
-- kind: conda
-  name: uvicorn
-  version: 0.30.6
-  build: py310hff52083_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py310hff52083_0.conda
-  sha256: 5132ce12e68229986f593c42384e89ff067ea62d8c1b18e4686809c2fa201f97
-  md5: 01f7a68bc784dce8e1d78d113e7138d6
-  depends:
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/uvicorn?source=conda-forge-mapping
-  size: 102257
-  timestamp: 1723660090917
 - kind: conda
   name: wasabi
   version: 1.1.2
@@ -5976,6 +5662,8 @@ packages:
   - python >=3.9
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/xgboost?source=conda-forge-mapping
   size: 15228
   timestamp: 1727635880733
 - kind: conda
@@ -5994,6 +5682,8 @@ packages:
   - python >=3.9
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/xgboost?source=conda-forge-mapping
   size: 15169
   timestamp: 1727639204682
 - kind: conda

--- a/runtime/pixi.toml
+++ b/runtime/pixi.toml
@@ -13,7 +13,6 @@ einops = "0.8.0"
 jsonpickle = "3.2.2"
 langchain = "0.3.3"
 langchain-community = "0.3.2"
-llama-cpp-python = "0.2.24"
 loguru = "0.7.*"
 nltk = "3.9.1"
 numba = "0.60.*"
@@ -32,6 +31,9 @@ tqdm = "4.66.*"
 transformers = "4.44.2"
 sentence-transformers = "2.0.0"
 xgboost = "2.1.1"
+
+[feature.base.pypi-dependencies]
+llama-cpp-python = { version = "==0.3.1" }
 
 # CPU DEPENDENCIES
 [feature.cpu]


### PR DESCRIPTION
Updated llama-cpp-python  to 0.3.1 using Pypi.

Conda had 0.2.24 as the latest version. I was not able to run any ChatModel in langchain in this version (was getting an error that Llama.create_chat_completion() got an unexpected keyword argument 'logprobs')